### PR TITLE
when down is pressed jump to lower level.

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -473,9 +473,9 @@ void game_input(int c)
 	case 's':
 		/* ignore drops until the first update after a spawn */
 		if(!just_spawned) {
-			next_pos[0] = pos[0] + 1;
-			if(collision(cur_piece, next_pos)) {
-				next_pos[0] = pos[0];
+			next_pos[0] = PF_ROWS;
+			while (collision(cur_piece, next_pos)) {
+				next_pos[0]--;
 			}
 		}
 		break;


### PR DESCRIPTION
That's good fun! One thing I enjoyed in the GameBoy tetris, especially after a few hours of playing, is that pressing down key was leading to a sharp jump of the piece to the lower level instead of accelerating it. I am filing this PR about it, feel free to ignore it if you don't want that feature.